### PR TITLE
Support for Linux

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,4 +22,5 @@ export const isGreasyForkUrl = url => {
 export const getExecutableFilename = (platform) => ({
 	win32: 'Melvor Idle.exe',
 	darwin: 'Melvor Idle.app',
+	linux: 'Melvor Idle',
 }[platform]);


### PR DESCRIPTION
Following on from the work in https://github.com/CherryMace/melvor-mod-manager/pull/4, the Linux build does not need the changes to `packageDir`, but the executable does not have an extension and so the appropriate substitution has been made.

With this change, installing mods from Discover, disabling and reenabling mods, and running Melvor with and without Steam seem to all work just as expected